### PR TITLE
멤버 개인 선호도 설정 관련 오류 수정

### DIFF
--- a/src/main/kotlin/skhu/msg/domain/member/api/PreferencesController.kt
+++ b/src/main/kotlin/skhu/msg/domain/member/api/PreferencesController.kt
@@ -1,6 +1,7 @@
 package skhu.msg.domain.member.api
 
 import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -19,8 +20,10 @@ class PreferencesController(
 ) {
 
     @PostMapping("/set")
-    fun setUpPreferences(@RequestBody requestUpdatePreferences: RequestUpdatePreferences) {
-        preferencesService.setUpPreferences(requestUpdatePreferences)
+    fun setUpPreferences(
+        principal: Principal, @RequestBody requestUpdatePreferences: RequestUpdatePreferences): ResponseEntity<String> {
+        preferencesService.setUpPreferences(principal, requestUpdatePreferences)
+        return ResponseEntity.ok("선호도 설정이 완료되었습니다.")
     }
 
     @GetMapping("/get")

--- a/src/main/kotlin/skhu/msg/domain/member/app/PreferencesService.kt
+++ b/src/main/kotlin/skhu/msg/domain/member/app/PreferencesService.kt
@@ -6,7 +6,7 @@ import java.security.Principal
 
 interface PreferencesService {
 
-    fun setUpPreferences(requestUpdatePreferences: RequestUpdatePreferences)
+    fun setUpPreferences(principal: Principal, requestUpdatePreferences: RequestUpdatePreferences)
 
     fun getPreferences(principal: Principal): ResponseMemberPreferences
 

--- a/src/main/kotlin/skhu/msg/domain/member/app/impl/PreferencesServiceImpl.kt
+++ b/src/main/kotlin/skhu/msg/domain/member/app/impl/PreferencesServiceImpl.kt
@@ -20,8 +20,8 @@ class PreferencesServiceImpl(
 ): PreferencesService {
 
     @Transactional
-    override fun setUpPreferences(requestUpdatePreferences: RequestUpdatePreferences) {
-        val memberEmail = requestUpdatePreferences.email
+    override fun setUpPreferences(principal: Principal, requestUpdatePreferences: RequestUpdatePreferences) {
+        val memberEmail = principal.name
         val newFastExitScore = requestUpdatePreferences.fastExitScore
         val newCoolingCarScore = requestUpdatePreferences.coolingCarScore
         val newGettingSeatScore = requestUpdatePreferences.gettingSeatScore
@@ -29,8 +29,8 @@ class PreferencesServiceImpl(
         val preferences = preferencesRepository.findByMemberEmail(memberEmail)
             ?: run {
                 val newPreferences = Preferences.create(
-                    fastExitScore = memberEmail,
-                    exitScore = newFastExitScore,
+                    memberEmail = memberEmail,
+                    fastExitScore = newFastExitScore,
                     coolingCarScore = newCoolingCarScore,
                     gettingSeatScore = newGettingSeatScore
                 )
@@ -40,6 +40,7 @@ class PreferencesServiceImpl(
         preferences.updateExitScore(newFastExitScore)
         preferences.updateCoolingScore(newCoolingCarScore)
         preferences.updateSeatScore(newGettingSeatScore)
+        preferencesRepository.save(preferences)
     }
 
     @Transactional(readOnly = true)

--- a/src/main/kotlin/skhu/msg/domain/member/dto/request/RequestUpdatePreferences.kt
+++ b/src/main/kotlin/skhu/msg/domain/member/dto/request/RequestUpdatePreferences.kt
@@ -1,13 +1,8 @@
 package skhu.msg.domain.member.dto.request
 
-import jakarta.validation.constraints.Email
 import jakarta.validation.constraints.NotBlank
 
 class RequestUpdatePreferences(
-    @field:Email(message = "이메일 형식이 올바르지 않습니다.")
-    @field:NotBlank(message = "이메일이 비어있습니다.")
-    var email: String,
-
     @field:NotBlank(message = "빠른 출구/환승 선호도가 비어있습니다.")
     var fastExitScore: Int,
 

--- a/src/main/kotlin/skhu/msg/domain/member/entity/Preferences.kt
+++ b/src/main/kotlin/skhu/msg/domain/member/entity/Preferences.kt
@@ -17,15 +17,15 @@ class Preferences(
 
     companion object {
         fun create (
-            fastExitScore: String,
-            exitScore: Int? = null,
+            memberEmail: String,
+            fastExitScore: Int? = null,
             coolingCarScore: Int? = null,
             gettingSeatScore: Int? = null,
         ): Preferences {
 
             return Preferences(
-                memberEmail = fastExitScore,
-                fastExitScore = exitScore,
+                memberEmail = memberEmail,
+                fastExitScore = fastExitScore,
                 coolingCarScore = coolingCarScore,
                 gettingSeatScore = gettingSeatScore,
             )


### PR DESCRIPTION
### 리스트
- 선호도 설정이 올바르게 저장되지 않던 오류 수정
- 멤버의 선호도를 불러오기 위해 멤버를 특정하는 방식 변경
@RequestBody로 멤버의 이메일을 가져와 멤버를 특정 -> Principal 객체를 통해 멤버를 특정하여 선호도를 가져오는 방식
이로 인해 로그인한 본인의 설정만 가져올 수 있도록 수정됨
- 기타 오타 수정