### PR TITLE
RefreshToken 도입

### DIFF
--- a/src/main/kotlin/skhu/msg/domain/auth/api/AuthController.kt
+++ b/src/main/kotlin/skhu/msg/domain/auth/api/AuthController.kt
@@ -1,6 +1,7 @@
 package skhu.msg.domain.auth.api
 
 import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.servlet.http.HttpServletRequest
 import jakarta.validation.Valid
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -8,6 +9,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import skhu.msg.domain.auth.app.AuthService
 import skhu.msg.domain.auth.dto.request.RequestLogin
+import skhu.msg.domain.auth.dto.request.RequestRefresh
 import skhu.msg.domain.auth.dto.response.ResponseToken
 
 @Tag(name = "인증")
@@ -18,8 +20,11 @@ class AuthController(
 ) {
 
     @PostMapping("/login")
-    fun joinOrLogin(@RequestBody @Valid requestLogin: RequestLogin): ResponseToken {
-        return authService.joinOrLogin(requestLogin)
-    }
+    fun joinOrLogin(@RequestBody @Valid requestLogin: RequestLogin): ResponseToken =
+        authService.joinOrLogin(requestLogin)
+
+    @PostMapping("/refresh")
+    fun refreshAccessToken(request: HttpServletRequest, @RequestBody @Valid requestRefresh: RequestRefresh): ResponseToken =
+         authService.refreshAccessToken(request, requestRefresh)
 
 }

--- a/src/main/kotlin/skhu/msg/domain/auth/app/AuthService.kt
+++ b/src/main/kotlin/skhu/msg/domain/auth/app/AuthService.kt
@@ -1,10 +1,14 @@
 package skhu.msg.domain.auth.app
 
+import jakarta.servlet.http.HttpServletRequest
 import skhu.msg.domain.auth.dto.request.RequestLogin
+import skhu.msg.domain.auth.dto.request.RequestRefresh
 import skhu.msg.domain.auth.dto.response.ResponseToken
 
 interface AuthService {
 
     fun joinOrLogin(requestLogin: RequestLogin): ResponseToken
+
+    fun refreshAccessToken(request: HttpServletRequest, requestRefresh: RequestRefresh): ResponseToken
 
 }

--- a/src/main/kotlin/skhu/msg/domain/auth/app/impl/AuthServiceImpl.kt
+++ b/src/main/kotlin/skhu/msg/domain/auth/app/impl/AuthServiceImpl.kt
@@ -1,35 +1,74 @@
 package skhu.msg.domain.auth.app.impl
 
+import jakarta.servlet.http.HttpServletRequest
+import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import skhu.msg.domain.auth.app.AuthService
 import skhu.msg.domain.auth.dto.request.RequestLogin
+import skhu.msg.domain.auth.dto.request.RequestRefresh
 import skhu.msg.domain.auth.dto.response.ResponseToken
 import skhu.msg.domain.member.dao.MemberRepository
 import skhu.msg.domain.member.entity.Member
 import skhu.msg.global.exception.ErrorCode
 import skhu.msg.global.exception.GlobalException
 import skhu.msg.global.jwt.TokenProvider
+import java.util.concurrent.TimeUnit
 
 @Service
 class AuthServiceImpl(
     private val memberRepository: MemberRepository,
     private val tokenProvider: TokenProvider,
-) : AuthService {
+    private val redisTemplate: RedisTemplate<String, Any>,
+): AuthService {
 
     @Transactional
     override fun joinOrLogin(requestLogin: RequestLogin): ResponseToken {
         return try {
-            with(requestLogin) {
-                if (!memberRepository.existsByEmail(email!!)) {
-                    val newMember = Member.create(email!!, nickname, uid)
-                    memberRepository.save(newMember)
-                }
-                tokenProvider.createToken(email!!)
+            val email = requestLogin.email ?: throw GlobalException(ErrorCode.INVALID_EMAIL)
+
+            if (existMemberByEmail(email)) {
+                val responseToken = tokenProvider.createToken(email)
+                saveRefreshToken(responseToken.refreshToken)
+                responseToken
+            } else {
+                val newMember = createNewMember(email, requestLogin.nickname, requestLogin.uid)
+                val responseToken = tokenProvider.createToken(newMember.email)
+                saveRefreshToken(responseToken.refreshToken)
+                responseToken
             }
         } catch (ex: Exception) {
-            throw GlobalException(ErrorCode.INVALID_LOGIN_INPUT)
+            throw GlobalException(ErrorCode.INTERNAL_SERVER_ERROR_LOGIN)
         }
+    }
+
+    override fun refreshAccessToken(request: HttpServletRequest, requestRefresh: RequestRefresh): ResponseToken {
+        return try {
+            val refreshToken = requestRefresh.refreshToken!!
+
+            validateRefreshToken(refreshToken)
+
+            tokenProvider.refreshAccessTokenByRefreshToken(request, refreshToken)
+        } catch (ex: Exception) {
+            throw GlobalException(ErrorCode.INVALID_JWT)
+        }
+    }
+
+    private fun existMemberByEmail(email: String): Boolean =
+        memberRepository.existsByEmail(email)
+
+    private fun createNewMember(email: String, nickname: String?, uid: String?): Member =
+        memberRepository.save(Member.create(email, nickname, uid))
+    private fun saveRefreshToken(refreshToken: String) {
+        val expiration: Long = tokenProvider.getExpirationTime(refreshToken)
+
+        redisTemplate.opsForValue()
+            .set(refreshToken, "refreshToken", expiration, TimeUnit.MILLISECONDS)
+    }
+
+    private fun validateRefreshToken(refreshToken: String) {
+        redisTemplate.opsForValue().get(refreshToken)
+            ?: throw GlobalException(ErrorCode.INVALID_JWT)
     }
 
 }

--- a/src/main/kotlin/skhu/msg/domain/auth/dto/request/RequestRefresh.kt
+++ b/src/main/kotlin/skhu/msg/domain/auth/dto/request/RequestRefresh.kt
@@ -1,0 +1,8 @@
+package skhu.msg.domain.auth.dto.request
+
+import jakarta.validation.constraints.NotBlank
+
+data class RequestRefresh(
+    @field:NotBlank(message = "refreshToken이 비어있습니다.")
+    var refreshToken: String? = null,
+)

--- a/src/main/kotlin/skhu/msg/domain/auth/dto/response/ResponseToken.kt
+++ b/src/main/kotlin/skhu/msg/domain/auth/dto/response/ResponseToken.kt
@@ -2,10 +2,17 @@ package skhu.msg.domain.auth.dto.response
 
 data class ResponseToken(
     var accessToken: String,
+    var refreshToken: String,
 ) {
 
     companion object {
-        fun create(accessToken: String) = ResponseToken(accessToken)
+        fun create(
+            accessToken: String,
+            refreshToken: String,
+        ) = ResponseToken(
+            accessToken = accessToken,
+            refreshToken = refreshToken,
+        )
     }
 
 }

--- a/src/main/kotlin/skhu/msg/global/config/RedisConfig.kt
+++ b/src/main/kotlin/skhu/msg/global/config/RedisConfig.kt
@@ -9,7 +9,7 @@ import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.data.redis.serializer.StringRedisSerializer
 
 @Configuration
-class RedisConfig1(
+class RedisConfig(
     @Value("\${spring.data.redis.host}") val host: String,
     @Value("\${spring.data.redis.port}") val port: Int,
 ) {

--- a/src/main/kotlin/skhu/msg/global/exception/ErrorCode.kt
+++ b/src/main/kotlin/skhu/msg/global/exception/ErrorCode.kt
@@ -23,6 +23,10 @@ enum class ErrorCode(
     INVALID_WEAK_COOLING_CAR(HttpStatus.BAD_REQUEST, "약냉방 차량 정보가 올바르지 않습니다."),
     INVALID_RECOMMEND_CAR(HttpStatus.BAD_REQUEST, "추천 차량 값이 올바르지 않습니다."),
     INVALID_JWT(HttpStatus.BAD_REQUEST, "토큰 값이 비어있거나 올바르지 않습니다."),
+    INVALID_EMAIL(HttpStatus.BAD_REQUEST, "이메일 값이 올바르지 않습니다."),
+
+    // 403 - Forbidden
+    FORBIDDEN_TOKEN(HttpStatus.FORBIDDEN, "권한 정보가 없는 토큰입니다."),
 
     // 404 - Not Found
     NOT_FOUND_STATION(HttpStatus.NOT_FOUND, "지하철역을 찾을 수 없습니다."),
@@ -36,5 +40,8 @@ enum class ErrorCode(
 
     // 500 - Internal Server Error
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 에러가 발생했습니다."),
+    INTERNAL_SERVER_ERROR_REDIS(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 에러가 발생했습니다. (Redis)"),
+    INTERNAL_SERVER_ERROR_JWT(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 에러가 발생했습니다. (JWT)"),
+    INTERNAL_SERVER_ERROR_LOGIN(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 에러가 발생했습니다. (로그인)"),
 
 }

--- a/src/main/kotlin/skhu/msg/global/jwt/JwtFilter.kt
+++ b/src/main/kotlin/skhu/msg/global/jwt/JwtFilter.kt
@@ -16,10 +16,12 @@ class JwtFilter (
     override fun doFilter(request: ServletRequest, response: ServletResponse, chain: FilterChain) {
         val token = tokenProvider.resolveToken(request as HttpServletRequest)
 
-        if (StringUtils.hasText(token)) {
-            if (tokenProvider.validateToken(token)) {
-                val authentication: Authentication = tokenProvider.getAuthentication(token!!)
-                SecurityContextHolder.getContext().authentication = authentication
+        if (request.requestURI != "/api/v1/auth/refresh") {
+            if (StringUtils.hasText(token)) {
+                if (tokenProvider.validateToken(token!!)) {
+                    val authentication: Authentication = tokenProvider.getAuthentication(token!!)
+                    SecurityContextHolder.getContext().authentication = authentication
+                }
             }
         }
 


### PR DESCRIPTION
### 설명
- 로그인 시 AccessToken과 함께 RefreshToken도 발급
- RefreshToken는 AccessToken 재발급에만 관여, 사용자 인증에 사용되지 않음
- RefreshToken은 만료되기 전까지 Redis에 저장
- AccessToken이 만료되는 시간을 줄일 수 있기 때문에 토큰이 탈취되더라도 빠른 시간내에 만료되는 것을 기대, 즉 보안성 강화
> JWT는 한 번 생성되면 만료되기 전까지 완전히 없애는 것이 불가능하기 때문에 AccessToken 만료기한을 길게 잡을 수록 위험이 증가될 가능성 존재