### PR TITLE
Docker 이미지 빌드 시 주입할 환경변수 추가

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -60,7 +60,10 @@ jobs:
           DB_PORT=${{ secrets.DB_PORT }}
           DB_URI=${{ secrets.DB_URI }}
           DB_NAME=${{ secrets.DB_NAME }}
+          REDIS_HOST=${{ secrets.REDIS_HOST }}
+          REDIS_PORT=${{ secrets.REDIS_PORT }}
           JWT_SECRET=${{ secrets.JWT_SECRET }}
           JWT_VALIDITY_TIME=${{ secrets.JWT_VALIDITY_TIME }}
+          JWT_REFRESH_VALIDITY_TIME=${{ secrets.JWT_REFRESH_VALIDITY_TIME }}
           SEOUL_API_KEY=${{ secrets.SEOUL_API_KEY }}
           SK_API_KEY=${{ secrets.SK_API_KEY }}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,7 +7,7 @@ spring:
       database: ${DB_NAME}
     redis:
       host: ${REDIS_HOST}
-      port: 6379
+      port: ${REDIS_PORT}
 jwt:
   secret: ${JWT_SECRET}
   access-token-validity-in-milliseconds: ${JWT_VALIDITY_TIME}


### PR DESCRIPTION
### 설명
- 기존 포트의 문제가 아니라 깃허브 액션에서 도커 이미지를 빌드하는 과정 중 추가해야 하는 환경변수를 추가하지 않아서 발생한 오류
- workflows에 추가하면서 문제 해결