### PR TITLE
실시간 지하철 혼잡도 API 사용 부담 완화를 위한 메소드 레벨에서 캐싱 적용

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-mongodb")
     implementation("org.springframework.boot:spring-boot-starter-data-redis")
     implementation("org.springframework.boot:spring-boot-starter-cache")
+    implementation("com.github.ben-manes.caffeine:caffeine:3.1.8")
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-validation")

--- a/src/main/kotlin/skhu/msg/domain/metro/app/impl/MetroServiceImpl.kt
+++ b/src/main/kotlin/skhu/msg/domain/metro/app/impl/MetroServiceImpl.kt
@@ -1,9 +1,6 @@
 package skhu.msg.domain.metro.app.impl
 
-import okhttp3.OkHttpClient
-import okhttp3.Request
 import org.json.JSONObject
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import skhu.msg.domain.member.dao.PreferencesRepository
@@ -14,19 +11,16 @@ import skhu.msg.domain.metro.data.WeakCoolingCar
 import skhu.msg.domain.metro.dto.response.*
 import skhu.msg.global.exception.ErrorCode
 import skhu.msg.global.exception.GlobalException
-import java.net.URLEncoder.encode
 import java.security.Principal
 
 @Service
 class MetroServiceImpl(
-    @Value("\${api.key.seoul}") private val SEOUL_API_KEY: String,
-    @Value("\${api.key.sk}") private val SK_API_KEY: String,
-    @Value("\${api.key.path}") private val PATH_API_KEY: String,
     private val preferencesRepository: PreferencesRepository,
+    private val openApiConnector: OpenApiConnector,
 ): MetroService {
 
     override fun getArrivingTrainsForStation(stationName: String, subwayLine: String): List<ResponseArrivalTrain> {
-        val jsonObject = getRealTimeArrivalTrains(stationName)
+        val jsonObject = openApiConnector.getRealTimeArrivalTrains(stationName)
         val jsonArray = jsonObject.getJSONArray("realtimeArrivalList")
         val responseArrivalTrainList = mutableListOf<ResponseArrivalTrain>()
 
@@ -44,7 +38,7 @@ class MetroServiceImpl(
     }
 
     override fun getCongestionForTrain(subwayLine: String, trainNo: String): ResponseCongestion {
-        val jsonObject = getRealTimeCongestion(subwayLine, trainNo)
+        val jsonObject = openApiConnector.getRealTimeCongestion(subwayLine, trainNo)
 
         return mapToResponseCongestion(jsonObject)
     }
@@ -55,7 +49,7 @@ class MetroServiceImpl(
 
         validateStationCoordinate(startStationCoordinate, endStationCoordinate)
 
-        val jsonObject = getTransitPath(startStationCoordinate, endStationCoordinate)
+        val jsonObject = openApiConnector.getTransitPath(startStationCoordinate, endStationCoordinate)
 
         return mapToResponseTransitPathAndAddFastTransferCar(jsonObject)
     }
@@ -115,28 +109,6 @@ class MetroServiceImpl(
     /**
      *  getArrivingTrainsForStation()에서 사용하는 메소드
      */
-    private fun getRealTimeArrivalTrains(stationName: String): JSONObject {
-        val client = OkHttpClient()
-
-        val encodedStationName = encode(stationName, "UTF-8")
-
-        val url = "http://swopenapi.seoul.go.kr/api/subway/${SEOUL_API_KEY}/json/realtimeStationArrival/0/15/${encodedStationName}"
-
-        val request = Request.Builder()
-            .url(url)
-            .get()
-            .build()
-
-        val response = client.newCall(request).execute()
-
-        return try {
-            val responseBody = response.body?.string()
-            JSONObject(responseBody)
-        } catch (e: Exception) {
-            throw GlobalException(ErrorCode.NOT_FOUND_ARRIVAL_TRAIN)
-        }
-    }
-
     private fun mapToResponseArrivalTrain(train: JSONObject): ResponseArrivalTrain {
         return ResponseArrivalTrain.create(
             subwayId = train.getString("subwayId"),
@@ -158,29 +130,6 @@ class MetroServiceImpl(
     /**
      *  getCongestionForTrain()에서 사용하는 메소드
      */
-    private fun getRealTimeCongestion(subwayLine: String, trainNo: String): JSONObject {
-        val client = OkHttpClient()
-
-        val url = "https://apis.openapi.sk.com/puzzle/subway/congestion/rltm/trains/${subwayLine}/${trainNo}"
-
-        val request = Request.Builder()
-            .url(url)
-            .get()
-            .addHeader("accept", "application/json")
-            .addHeader("Content-Type", "application/json")
-            .addHeader("appKey", SK_API_KEY)
-            .build()
-
-        val response = client.newCall(request).execute()
-        val json = response.body?.string() ?: throw RuntimeException("Response body is null")
-
-        return try {
-            JSONObject(json).getJSONObject("data").getJSONObject("congestionResult")
-        } catch (e: Exception) {
-            throw GlobalException(ErrorCode.INTERNAL_SERVER_ERROR)
-        }
-    }
-
     private fun mapToResponseCongestion(congestion: JSONObject) =
         ResponseCongestion.create(
             congestionTrain = congestion.getString("congestionTrain"),
@@ -200,29 +149,6 @@ class MetroServiceImpl(
         startStationCoordinate.crdnt_y ?: throw Exception("출발역의 좌표를 찾을 수 없습니다.")
         endStationCoordinate.crdnt_x ?: throw Exception("도착역의 좌표를 찾을 수 없습니다.")
         endStationCoordinate.crdnt_y ?: throw Exception("도착역의 좌표를 찾을 수 없습니다.")
-    }
-
-    private fun getTransitPath(startStationCoordinate: SubwayStation, endStationCoordinate: SubwayStation): JSONObject {
-        val client = OkHttpClient()
-
-        val startX = startStationCoordinate.crdnt_x
-        val startY = startStationCoordinate.crdnt_y
-        val endX = endStationCoordinate.crdnt_x
-        val endY = endStationCoordinate.crdnt_y
-
-        val url = "http://ws.bus.go.kr/api/rest/pathinfo/getPathInfoBySubway?ServiceKey=${PATH_API_KEY}&startX=${startX}&startY=${startY}&endX=${endX}&endY=${endY}&resultType=json"
-
-        val request = Request.Builder()
-            .url(url)
-            .get()
-            .addHeader("accept", "application/json")
-            .addHeader("Content-Type", "application/json")
-            .build()
-
-        val response = client.newCall(request).execute()
-        val json = response.body?.string() ?: throw GlobalException(ErrorCode.INTERNAL_SERVER_ERROR)
-
-        return JSONObject(json)
     }
 
     private fun mapToResponseTransitPathAndAddFastTransferCar(jsonObject: JSONObject): List<ResponseTransitPath> {

--- a/src/main/kotlin/skhu/msg/domain/metro/app/impl/OpenApiConnector.kt
+++ b/src/main/kotlin/skhu/msg/domain/metro/app/impl/OpenApiConnector.kt
@@ -1,0 +1,90 @@
+package skhu.msg.domain.metro.app.impl
+
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.json.JSONObject
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.cache.annotation.Cacheable
+import org.springframework.stereotype.Service
+import skhu.msg.domain.metro.data.SubwayStation
+import skhu.msg.global.exception.ErrorCode
+import skhu.msg.global.exception.GlobalException
+import java.net.URLEncoder
+
+@Service
+class OpenApiConnector(
+    @Value("\${api.key.seoul}") private val SEOUL_API_KEY: String,
+    @Value("\${api.key.sk}") private val SK_API_KEY: String,
+    @Value("\${api.key.path}") private val PATH_API_KEY: String,
+) {
+
+    @Cacheable(value = ["congestion"], key = "#subwayLine + #trainNo")
+    fun getRealTimeCongestion(subwayLine: String, trainNo: String): JSONObject {
+        val client = OkHttpClient()
+
+        val url = "https://apis.openapi.sk.com/puzzle/subway/congestion/rltm/trains/${subwayLine}/${trainNo}"
+
+        val request = Request.Builder()
+            .url(url)
+            .get()
+            .addHeader("accept", "application/json")
+            .addHeader("Content-Type", "application/json")
+            .addHeader("appKey", SK_API_KEY)
+            .build()
+
+        val response = client.newCall(request).execute()
+        val json = response.body?.string() ?: throw RuntimeException("Response body is null")
+
+        return try {
+            JSONObject(json).getJSONObject("data").getJSONObject("congestionResult")
+        } catch (e: Exception) {
+            throw GlobalException(ErrorCode.INTERNAL_SERVER_ERROR)
+        }
+    }
+
+    fun getRealTimeArrivalTrains(stationName: String): JSONObject {
+        val client = OkHttpClient()
+
+        val encodedStationName = URLEncoder.encode(stationName, "UTF-8")
+
+        val url = "http://swopenapi.seoul.go.kr/api/subway/${SEOUL_API_KEY}/json/realtimeStationArrival/0/15/${encodedStationName}"
+
+        val request = Request.Builder()
+            .url(url)
+            .get()
+            .build()
+
+        val response = client.newCall(request).execute()
+
+        return try {
+            val responseBody = response.body?.string()
+            JSONObject(responseBody)
+        } catch (e: Exception) {
+            throw GlobalException(ErrorCode.NOT_FOUND_ARRIVAL_TRAIN)
+        }
+    }
+
+    fun getTransitPath(startStationCoordinate: SubwayStation, endStationCoordinate: SubwayStation): JSONObject {
+        val client = OkHttpClient()
+
+        val startX = startStationCoordinate.crdnt_x
+        val startY = startStationCoordinate.crdnt_y
+        val endX = endStationCoordinate.crdnt_x
+        val endY = endStationCoordinate.crdnt_y
+
+        val url = "http://ws.bus.go.kr/api/rest/pathinfo/getPathInfoBySubway?ServiceKey=${PATH_API_KEY}&startX=${startX}&startY=${startY}&endX=${endX}&endY=${endY}&resultType=json"
+
+        val request = Request.Builder()
+            .url(url)
+            .get()
+            .addHeader("accept", "application/json")
+            .addHeader("Content-Type", "application/json")
+            .build()
+
+        val response = client.newCall(request).execute()
+        val json = response.body?.string() ?: throw GlobalException(ErrorCode.INTERNAL_SERVER_ERROR)
+
+        return JSONObject(json)
+    }
+
+}

--- a/src/main/kotlin/skhu/msg/global/config/CacheConfig.kt
+++ b/src/main/kotlin/skhu/msg/global/config/CacheConfig.kt
@@ -1,16 +1,32 @@
 package skhu.msg.global.config
 
+import com.github.benmanes.caffeine.cache.Caffeine
+import org.springframework.cache.CacheManager
 import org.springframework.cache.annotation.EnableCaching
-import org.springframework.cache.concurrent.ConcurrentMapCacheManager
+import org.springframework.cache.caffeine.CaffeineCache
+import org.springframework.cache.support.SimpleCacheManager
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import java.util.concurrent.TimeUnit
 
 @EnableCaching
 @Configuration
 class CacheConfig {
 
+    final val cacheNames = "congestion"
+    final val expireAfterWrite = 60L
+    final val maximumSize = 1000L
+    final val caffeine = Caffeine.newBuilder()
+        .expireAfterWrite(expireAfterWrite, TimeUnit.SECONDS)
+        .maximumSize(maximumSize)
+        .build<Any, Any>()
+
     @Bean
-    fun cacheManager() =
-        ConcurrentMapCacheManager("metroCache")
+    fun cacheManager(): CacheManager {
+        val cacheManager = SimpleCacheManager()
+        val caches = mutableListOf(CaffeineCache(cacheNames, caffeine))
+        cacheManager.setCaches(caches)
+        return cacheManager
+    }
 
 }

--- a/src/test/kotlin/skhu/msg/domain/metro/app/impl/MetroServiceImplTest.kt
+++ b/src/test/kotlin/skhu/msg/domain/metro/app/impl/MetroServiceImplTest.kt
@@ -1,0 +1,17 @@
+package skhu.msg.domain.metro.app.impl
+
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+import org.junit.jupiter.api.Assertions.*
+
+class MetroServiceImplTest {
+
+    @BeforeEach
+    fun setUp() {
+    }
+
+    @Test
+    fun getCongestionForTrain() {
+    }
+}

--- a/src/test/kotlin/skhu/msg/domain/metro/app/impl/OpenApiConnectorTest.kt
+++ b/src/test/kotlin/skhu/msg/domain/metro/app/impl/OpenApiConnectorTest.kt
@@ -1,0 +1,17 @@
+package skhu.msg.domain.metro.app.impl
+
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+import org.junit.jupiter.api.Assertions.*
+
+class OpenApiConnectorTest {
+
+    @BeforeEach
+    fun setUp() {
+    }
+
+    @Test
+    fun getRealTimeCongestion() {
+    }
+}


### PR DESCRIPTION
### 결과
- 약 1분 안에 동일한 요청을 하는 경우 메소드가 실행되지 않고 캐싱된 결과를 응답
- 지하철 실시간 혼잡도 데이터는 약 1분 이상은 데이터가 변하지 않는 경향이 강하기 때문에
1분 정도의 데이터 신선도를 낮추더라도 API 사용 요금 감소와 성능 향상이 더 좋다고 판단하여 적용하기로 결정
- 모든 작업은 같은 인자를 전달하는 요청
- 관련된 이슈 및 해결 : #40 
<img width="240" alt="스크린샷 2023-08-31 오후 10 27 14" src="https://github.com/MetroSmartGuide/msg-server/assets/107793780/e4e6285a-b4b7-4a3d-a20b-d73eb36dcc91">  