### PR TITLE
HTTP Client 라이브러리 마이그레이션

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,7 +34,6 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0")
-    implementation("com.squareup.okhttp3:okhttp:4.10.0")
     implementation("org.json:json:20230618")
     implementation("io.jsonwebtoken:jjwt-api:0.11.5")
     runtimeOnly("io.jsonwebtoken:jjwt-impl:0.11.5")

--- a/src/main/kotlin/skhu/msg/domain/metro/app/impl/OpenApiConnector.kt
+++ b/src/main/kotlin/skhu/msg/domain/metro/app/impl/OpenApiConnector.kt
@@ -1,15 +1,17 @@
 package skhu.msg.domain.metro.app.impl
 
-import okhttp3.OkHttpClient
-import okhttp3.Request
 import org.json.JSONObject
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.cache.annotation.Cacheable
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpMethod
 import org.springframework.stereotype.Component
+import org.springframework.web.client.RestTemplate
 import skhu.msg.domain.metro.data.SubwayStation
 import skhu.msg.global.exception.ErrorCode
 import skhu.msg.global.exception.GlobalException
-import java.net.URLEncoder
+import java.net.URL
 
 @Component
 class OpenApiConnector(
@@ -20,75 +22,72 @@ class OpenApiConnector(
 
     @Cacheable(value = ["congestion"], key = "#subwayLine + #trainNo")
     fun getRealTimeCongestion(subwayLine: String, trainNo: String): JSONObject {
-        val client = OkHttpClient()
+        val restTemplate = RestTemplate()
 
         val url = "https://apis.openapi.sk.com/puzzle/subway/congestion/rltm/trains/${subwayLine}/${trainNo}"
 
-        val request = Request.Builder()
-            .url(url)
-            .get()
-            .addHeader("accept", "application/json")
-            .addHeader("Content-Type", "application/json")
-            .addHeader("appKey", SK_API_KEY)
-            .build()
+        val httpEntity = HttpEntity<String>(
+            HttpHeaders().apply {
+                set("accept", "application/json")
+                set("Content-Type", "application/json")
+                set("appKey", SK_API_KEY)
+            })
 
-        val response = client.newCall(request).execute()
-        val json = response.body?.string() ?: throw GlobalException(ErrorCode.INTERNAL_SERVER_ERROR)
+        val response = restTemplate.exchange(url, HttpMethod.GET, httpEntity, String::class.java)
 
-        return try {
-            JSONObject(json).getJSONObject("data").getJSONObject("congestionResult")
-        } catch (e: Exception) {
+        if (!response.statusCode.is2xxSuccessful) {
             throw GlobalException(ErrorCode.NOT_FOUND_CONGESTION)
         }
+
+        return JSONObject(response.body)
+            .getJSONObject("data").getJSONObject("congestionResult") ?: throw GlobalException(ErrorCode.NOT_FOUND_CONGESTION)
     }
 
     fun getRealTimeArrivalTrains(stationName: String): JSONObject {
-        val client = OkHttpClient()
+        val restTemplate = RestTemplate()
 
-        val encodedStationName = URLEncoder.encode(stationName, "UTF-8")
+        val url = "http://swopenapi.seoul.go.kr/api/subway/$SEOUL_API_KEY/json/realtimeStationArrival/0/15/$stationName"
 
-        val url = "http://swopenapi.seoul.go.kr/api/subway/${SEOUL_API_KEY}/json/realtimeStationArrival/0/15/${encodedStationName}"
+        val httpEntity = HttpEntity<String>(
+            HttpHeaders().apply {
+                set("accept", "application/json")
+                set("Content-Type", "application/x-www-form-urlencoded;charset=utf-8")
+            })
 
-        val request = Request.Builder()
-            .url(url)
-            .get()
-            .build()
+        val response = restTemplate.exchange(url, HttpMethod.GET, httpEntity, String::class.java)
 
-        val response = client.newCall(request).execute()
-        val json = response.body?.string() ?: throw GlobalException(ErrorCode.INTERNAL_SERVER_ERROR)
-
-        return try {
-            JSONObject(json)
-        } catch (e: Exception) {
-            throw GlobalException(ErrorCode.NOT_FOUND_ARRIVAL_TRAIN)
+        if (!response.statusCode.is2xxSuccessful) {
+            throw GlobalException(ErrorCode.INTERNAL_SERVER_ERROR)
         }
+
+        val responseBody = response.body ?: throw GlobalException(ErrorCode.NOT_FOUND_ARRIVAL_TRAIN)
+        return JSONObject(responseBody)
     }
 
     fun getTransitPath(startStationCoordinate: SubwayStation, endStationCoordinate: SubwayStation): JSONObject {
-        val client = OkHttpClient()
+        val restTemplate = RestTemplate()
 
         val startX = startStationCoordinate.crdnt_x
         val startY = startStationCoordinate.crdnt_y
         val endX = endStationCoordinate.crdnt_x
         val endY = endStationCoordinate.crdnt_y
+        val url = "http://ws.bus.go.kr/api/rest/pathinfo/getPathInfoBySubway?serviceKey=$PATH_API_KEY&startX=$startX&startY=$startY&endX=$endX&endY=$endY&resultType=json"
+        val accessUrl = URL(url).toURI()
 
-        val url = "http://ws.bus.go.kr/api/rest/pathinfo/getPathInfoBySubway?ServiceKey=${PATH_API_KEY}&startX=${startX}&startY=${startY}&endX=${endX}&endY=${endY}&resultType=json"
+        val httpEntity = HttpEntity<String>(
+            HttpHeaders().apply {
+                set("accept", "application/json")
+                set("Content-Type", "application/json")
+            })
 
-        val request = Request.Builder()
-            .url(url)
-            .get()
-            .addHeader("accept", "application/json")
-            .addHeader("Content-Type", "application/json")
-            .build()
+        val response = restTemplate.exchange(accessUrl, HttpMethod.GET, httpEntity, String::class.java)
 
-        val response = client.newCall(request).execute()
-        val json = response.body?.string() ?: throw GlobalException(ErrorCode.INTERNAL_SERVER_ERROR)
-
-        return try {
-            JSONObject(json)
-        } catch (e: Exception) {
-            throw GlobalException(ErrorCode.NOT_FOUND_TRANSIT_PATH)
+        if (!response.statusCode.is2xxSuccessful) {
+            throw GlobalException(ErrorCode.INTERNAL_SERVER_ERROR)
         }
+
+        val responseBody = response.body ?: throw GlobalException(ErrorCode.NOT_FOUND_TRANSIT_PATH)
+        return JSONObject(responseBody)
     }
 
 }


### PR DESCRIPTION
- 기존 OkHttp에서 RestTemplate로 변경

## 변경 사유
- 프로젝트 특성 상 외부 API를 더 추가할 수도 있기 때문에 HTTP 클라이언트 중요성이 커질 것으로 생각, 그래서 초반부터 스프링 생태계와 연결된 RestTemplate를 사용하는 것이 맞다고 판단